### PR TITLE
Fix deploy workflow: allow workflow_dispatch to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,15 +42,15 @@ jobs:
         run: bun run build
 
       - uses: actions/configure-pages@v5
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
 
       - uses: actions/upload-pages-artifact@v3
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
         with:
           path: dist
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Why

Pages source was just switched from legacy branch-deploy to GitHub Actions. With the old conditional (`github.event_name == 'push'`), the deploy job was **skipped on `workflow_dispatch`**, so manual reruns couldn't redeploy — the site stays 404 until the next code push.

## Fix

Relax the conditional on `configure-pages`, `upload-pages-artifact`, and the `deploy` job from:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/master'
```

to:

```yaml
if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
```

- ✅ `push` to master → deploys
- ✅ `workflow_dispatch` on master → deploys (was: skipped)
- ✅ `pull_request` → still skipped (correct)

## Test plan

- [ ] Merge → on-push run deploys, `https://emailservicechecker.com/` returns 200.
- [ ] Re-running via "Run workflow" button in Actions also deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)