### PR TITLE
Catppuccin Latte redesign + per-provider SEO pages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "email-service-checker",
       "dependencies": {
-        "@fontsource-variable/figtree": "^5.1.0",
-        "@fontsource-variable/fraunces": "^5.1.0",
+        "@fontsource-variable/bricolage-grotesque": "^5.2.10",
         "@fontsource-variable/jetbrains-mono": "^5.1.0",
+        "@fontsource-variable/onest": "^5.2.11",
         "@tailwindcss/cli": "^4.3.0",
         "tailwindcss": "^4.3.0",
       },
@@ -37,11 +37,11 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@fontsource-variable/figtree": ["@fontsource-variable/figtree@5.2.10", "", {}, "sha512-a5Gumbpy3mdd+Yg31g6Qb7CmjYbrfyutJa3bWfP5q8A4GclIOwX7mI+ZuSHsJnw/mHvW6r9oh1AHJcJTIxK4JA=="],
-
-    "@fontsource-variable/fraunces": ["@fontsource-variable/fraunces@5.2.9", "", {}, "sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw=="],
+    "@fontsource-variable/bricolage-grotesque": ["@fontsource-variable/bricolage-grotesque@5.2.10", "", {}, "sha512-5EDsCqgGpKVcJWE4sg9ydli+t5WM97mISYw5lla/Ev4z71FwXh1oN0YUU8xjkRW9+wBCGD9R+ntAvI8G4bUFJg=="],
 
     "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
+
+    "@fontsource-variable/onest": ["@fontsource-variable/onest@5.2.11", "", {}, "sha512-knJww1KxK4g66+qu90q3CPBvl4zhL5oDRi3/JMkYMmlhW3OgyRgT4MMfgd6jg2lvho7bLPAXfsYPh59h0yzwUA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <meta name="theme-color" content="#f4ede0">
+    <meta name="theme-color" content="#eff1f5">
     <title>Email Service Checker — Find Email Providers</title>
     <meta name="title"       content="Email Service Checker — Find Email Providers">
     <meta name="description" content="Identify which email provider, security gateway, or forwarder handles a domain's mail. Detects Google Workspace, Microsoft 365, Proofpoint, Mimecast, Cloudflare Email Routing, Fastmail, Zoho, Proton, and many more from public MX records.">
@@ -19,8 +19,8 @@
     <link rel="icon" href="logo.webp" type="image/webp">
     <link rel="preconnect" href="https://dns.google">
     <link rel="stylesheet" href="styles.css">
-    <link rel="preload" as="font" type="font/woff2" href="fonts/fraunces-latin-full-normal.woff2" crossorigin>
-    <link rel="preload" as="font" type="font/woff2" href="fonts/figtree-latin-wght-normal.woff2" crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="fonts/bricolage-grotesque-latin-standard-normal.woff2" crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="fonts/onest-latin-wght-normal.woff2" crossorigin>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-1TBL4YJLRE"></script>
     <script>
@@ -45,56 +45,50 @@
     <script type="module" src="main.js"></script>
 </head>
 <body>
-    <main class="relative z-10 grid place-items-start justify-center px-[clamp(1rem,3.5vw,2rem)] pt-[clamp(1.5rem,4vw,3rem)] pb-[clamp(2rem,6vw,4rem)]">
-        <div class="w-full max-w-[42rem] grid gap-[clamp(1.75rem,4vw,2.75rem)]">
+    <main class="relative z-10 flex justify-center px-6 pt-16 pb-20 sm:pt-20">
+        <div class="w-full max-w-[40rem] flex flex-col gap-10">
 
-            <header class="text-center grid gap-[0.85rem] justify-items-center">
-                <img class="crest" src="logo.webp" alt="Email Service Checker insignia">
-                <p class="font-body font-medium uppercase tracking-[0.32em] text-[0.7rem] text-ink-faded">Bureau of Mail Exchange · est. MMXXIV</p>
-                <h1 class="display-title">What's <em>actually</em> handling the mail?</h1>
-                <p class="max-w-[38ch] text-ink-soft text-[clamp(0.95rem,2.3vw,1.05rem)] text-pretty">
-                    Type a domain or an email address. We'll inspect its public MX records and report the provider, security gateway, or forwarder responsible.
+            <header class="flex flex-col items-center text-center gap-5">
+                <img class="crest" src="logo.webp" alt="">
+                <p class="eyebrow">MX inspection</p>
+                <h1 class="display-hero">What's <em>actually</em> handling the mail?</h1>
+                <p class="max-w-[44ch] text-subtext-1 text-[1.0625rem]">
+                    Type a domain or an email address. We'll look up its public MX records and report the provider, security gateway, or forwarder responsible.
                 </p>
-                <div class="flex items-center gap-3 mt-1 stencil before:content-[''] before:h-px before:w-[clamp(2rem,8vw,4rem)] before:bg-rule after:content-[''] after:h-px after:w-[clamp(2rem,8vw,4rem)] after:bg-rule">
-                    <span>Lookup · MX</span>
-                </div>
             </header>
 
-            <form id="check-form" class="paper-card paper-card--warm p-[clamp(1.25rem,3vw,1.75rem)] @container" autocomplete="off" novalidate>
-                <div class="flex justify-between mb-[0.9rem] stencil">
-                    <span>Form MX/04 — Domain Inspection Request</span>
-                    <span>Rev. 2026</span>
-                </div>
-                <div class="grid gap-[0.85rem] @md:grid-cols-[1fr_auto] @md:items-stretch">
-                    <label for="domain" class="sr-only">Domain or Email</label>
-                    <input
-                        id="domain"
-                        name="domain"
-                        type="text"
-                        class="input-display"
-                        placeholder="example.com or you@example.com"
-                        autocapitalize="off"
-                        spellcheck="false"
-                        required
-                        inputmode="email">
-                    <button type="submit" id="check-button" class="btn-stencil">
-                        <span id="check-button-label">Inspect</span>
-                    </button>
-                </div>
+            <form id="check-form" class="card p-3 sm:p-4 flex flex-col sm:flex-row gap-3" autocomplete="off" novalidate>
+                <label for="domain" class="sr-only">Domain or email</label>
+                <input
+                    id="domain"
+                    name="domain"
+                    type="text"
+                    class="field-input flex-1 min-w-0"
+                    placeholder="example.com or you@example.com"
+                    autocapitalize="off"
+                    spellcheck="false"
+                    required
+                    inputmode="email">
+                <button type="submit" id="check-button" class="btn-primary">
+                    <span id="check-button-label">Inspect</span>
+                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                        <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                </button>
             </form>
 
             <div id="result"></div>
         </div>
     </main>
 
-    <footer class="relative z-10 flex flex-wrap items-center justify-center gap-x-[1.6rem] gap-y-[0.6rem] px-[clamp(1rem,3.5vw,2rem)] pt-6 pb-9 border-t border-rule text-ink-faded text-sm">
-        <a href="https://github.com/viktopia/email-service-checker" target="_blank" rel="noopener" class="inline-flex items-center gap-[0.45rem] text-ink-soft no-underline hover:text-stamp-red transition-colors">
+    <footer class="relative z-10 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 px-6 py-8 text-subtext-0 text-sm">
+        <a href="https://github.com/viktopia/email-service-checker" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-subtext-1 hover:text-text transition-colors">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="w-4 h-4" aria-hidden="true">
                 <path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.18 6.84 9.5.5.09.68-.22.68-.48v-1.7c-2.78.61-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.9 1.53 2.35 1.09 2.93.83.09-.65.35-1.09.63-1.34-2.22-.25-4.56-1.11-4.56-4.95 0-1.09.39-1.98 1.03-2.68-.1-.26-.45-1.29.1-2.68 0 0 .84-.27 2.75 1.02A9.55 9.55 0 0112 6.9c.85.004 1.7.114 2.5.334 1.91-1.3 2.75-1.02 2.75-1.02.55 1.39.2 2.42.1 2.68.64.7 1.03 1.59 1.03 2.68 0 3.85-2.34 4.7-4.57 4.95.36.31.68.92.68 1.85v2.74c0 .26.18.58.69.48A10 10 0 0022 12c0-5.52-4.48-10-10-10z"/>
             </svg>
-            <span>Source on GitHub</span>
+            <span>GitHub</span>
         </a>
-        <span class="text-rule">·</span>
+        <span class="text-surface-1">·</span>
         <span>&copy; {{YEAR}} <a href="https://studio.viktopia.io" target="_blank" rel="noopener">Viktopia Studio</a></span>
     </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -4,23 +4,28 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="theme-color" content="#eff1f5">
-    <title>Email Service Checker — Find Email Providers</title>
-    <meta name="title"       content="Email Service Checker — Find Email Providers">
-    <meta name="description" content="Identify which email provider, security gateway, or forwarder handles a domain's mail. Detects Google Workspace, Microsoft 365, Proofpoint, Mimecast, Cloudflare Email Routing, Fastmail, Zoho, Proton, and many more from public MX records.">
-    <meta name="keywords"    content="email service checker, MX record lookup, find email provider, Google Workspace, Microsoft 365, Proofpoint, Mimecast, Cisco IronPort, Cloudflare Email Routing, Zoho Mail, Fastmail, ProtonMail, Yahoo Mail, Apple iCloud, AOL, Yandex, GMX, Tutanota, Migadu, SimpleLogin, addy.io, ForwardEmail, Amazon SES, Postmark, Mailgun, SendGrid">
+    <title>{{TITLE}}</title>
+    <meta name="title"       content="{{TITLE}}">
+    <meta name="description" content="{{DESCRIPTION}}">
     <meta name="author"      content="Viktor Petersson">
+    <meta name="robots"      content="index, follow, max-image-preview:large, max-snippet:-1">
+    <link rel="canonical"    href="{{CANONICAL}}">
 
     <meta property="og:type"        content="website">
-    <meta property="og:title"       content="Email Service Checker — Find Email Providers">
-    <meta property="og:description" content="Find out which provider, security gateway, or forwarder handles a domain's email, from public MX records.">
-    <meta property="og:image"       content="logo.webp">
+    <meta property="og:site_name"   content="Email Service Checker">
+    <meta property="og:title"       content="{{OG_TITLE}}">
+    <meta property="og:description" content="{{OG_DESCRIPTION}}">
+    <meta property="og:image"       content="https://emailservicechecker.com/logo.webp">
+    <meta property="og:url"         content="{{CANONICAL}}">
     <meta name="twitter:card"       content="summary">
+    <meta name="twitter:title"      content="{{OG_TITLE}}">
+    <meta name="twitter:description" content="{{OG_DESCRIPTION}}">
 
-    <link rel="icon" href="logo.webp" type="image/webp">
+    <link rel="icon" href="/logo.webp" type="image/webp">
     <link rel="preconnect" href="https://dns.google">
-    <link rel="stylesheet" href="styles.css">
-    <link rel="preload" as="font" type="font/woff2" href="fonts/bricolage-grotesque-latin-standard-normal.woff2" crossorigin>
-    <link rel="preload" as="font" type="font/woff2" href="fonts/onest-latin-wght-normal.woff2" crossorigin>
+    <link rel="stylesheet" href="/styles.css">
+    <link rel="preload" as="font" type="font/woff2" href="/fonts/bricolage-grotesque-latin-standard-normal.woff2" crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="/fonts/onest-latin-wght-normal.woff2" crossorigin>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-1TBL4YJLRE"></script>
     <script>
@@ -29,32 +34,19 @@
         gtag('js', new Date());
         gtag('config', 'G-1TBL4YJLRE');
     </script>
-    <script type="application/ld+json">
-        {
-            "@context": "https://schema.org",
-            "@type": "WebSite",
-            "name": "Email Service Checker",
-            "url": "https://emailservicechecker.com",
-            "potentialAction": {
-                "@type": "SearchAction",
-                "target": "https://emailservicechecker.com?domain={domain}",
-                "query-input": "required name=domain"
-            }
-        }
-    </script>
-    <script type="module" src="main.js"></script>
+    <script type="application/ld+json">{{JSON_LD}}</script>
+    <script type="module" src="/main.js"></script>
 </head>
 <body>
     <main class="relative z-10 flex justify-center px-6 pt-16 pb-20 sm:pt-20">
         <div class="w-full max-w-[40rem] flex flex-col gap-10">
 
             <header class="flex flex-col items-center text-center gap-5">
-                <img class="crest" src="logo.webp" alt="">
-                <p class="eyebrow">MX inspection</p>
-                <h1 class="display-hero">What's <em>actually</em> handling the mail?</h1>
-                <p class="max-w-[44ch] text-subtext-1 text-[1.0625rem]">
-                    Type a domain or an email address. We'll look up its public MX records and report the provider, security gateway, or forwarder responsible.
-                </p>
+                <a href="/" aria-label="Home" class="inline-block"><img class="crest" src="/logo.webp" alt=""></a>
+                {{BREADCRUMBS}}
+                <p class="eyebrow">{{HERO_EYEBROW}}</p>
+                <h1 class="display-hero">{{HERO_TITLE}}</h1>
+                <p class="max-w-[44ch] text-subtext-1 text-[1.0625rem]">{{HERO_LEDE}}</p>
             </header>
 
             <form id="check-form" class="card p-3 sm:p-4 flex flex-col sm:flex-row gap-3" autocomplete="off" novalidate>
@@ -70,7 +62,7 @@
                     required
                     inputmode="email">
                 <button type="submit" id="check-button" class="btn-primary">
-                    <span id="check-button-label">Inspect</span>
+                    <span id="check-button-label">Check</span>
                     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
                         <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
                     </svg>
@@ -78,6 +70,8 @@
             </form>
 
             <div id="result"></div>
+
+            {{PROFILE_SECTION}}
         </div>
     </main>
 
@@ -88,6 +82,8 @@
             </svg>
             <span>GitHub</span>
         </a>
+        <span class="text-surface-1">·</span>
+        <a href="/sitemap.xml" class="hover:text-text transition-colors">Sitemap</a>
         <span class="text-surface-1">·</span>
         <span>&copy; {{YEAR}} <a href="https://studio.viktopia.io" target="_blank" rel="noopener">Viktopia Studio</a></span>
     </footer>

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "clean": "rm -rf dist src/data/consumer-domains.ts"
   },
   "dependencies": {
-    "@fontsource-variable/figtree": "^5.1.0",
-    "@fontsource-variable/fraunces": "^5.1.0",
+    "@fontsource-variable/bricolage-grotesque": "^5.2.10",
     "@fontsource-variable/jetbrains-mono": "^5.1.0",
+    "@fontsource-variable/onest": "^5.2.11",
     "@tailwindcss/cli": "^4.3.0",
     "tailwindcss": "^4.3.0"
   },

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://emailservicechecker.com/</loc>
-    <lastmod>2024-05-15</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -16,9 +16,8 @@ const CSS   = join(ROOT, 'src/styles.css');
 const NM    = join(ROOT, 'node_modules');
 
 const FONT_FILES = [
-    '@fontsource-variable/fraunces/files/fraunces-latin-full-normal.woff2',
-    '@fontsource-variable/fraunces/files/fraunces-latin-full-italic.woff2',
-    '@fontsource-variable/figtree/files/figtree-latin-wght-normal.woff2',
+    '@fontsource-variable/bricolage-grotesque/files/bricolage-grotesque-latin-standard-normal.woff2',
+    '@fontsource-variable/onest/files/onest-latin-wght-normal.woff2',
     '@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2',
 ] as const;
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,19 +1,37 @@
 /**
  * Builds the static site into ./dist/
  *
- *   bun run build          – one-shot production build
- *   bun run dev / --serve  – serve dist with live reload via Bun's dev server
+ *   bun run build          one-shot production build
+ *   bun run dev / --serve  serve dist with live reload via Bun's dev server
+ *
+ * Emits a homepage and one SEO page per Provider at /provider/<slug>/,
+ * plus sitemap.xml and robots.txt — all generated from src/providers.ts.
  */
 
-import { existsSync, rmSync, cpSync, statSync, readdirSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
+import { CATEGORY_LABEL, PROVIDERS, providerSlug } from '../src/providers.ts';
+import type { Provider } from '../src/types.ts';
 
-const ROOT  = new URL('..', import.meta.url).pathname;
-const DIST  = join(ROOT, 'dist');
-const PUBL  = join(ROOT, 'public');
-const HTML  = join(ROOT, 'index.html');
-const CSS   = join(ROOT, 'src/styles.css');
-const NM    = join(ROOT, 'node_modules');
+const ROOT = new URL('..', import.meta.url).pathname;
+const DIST = join(ROOT, 'dist');
+const PUBL = join(ROOT, 'public');
+const HTML = join(ROOT, 'index.html');
+const CSS  = join(ROOT, 'src/styles.css');
+const NM   = join(ROOT, 'node_modules');
+
+const SITE_ORIGIN = 'https://emailservicechecker.com';
+const YEAR = String(new Date().getFullYear());
+const TODAY = new Date().toISOString().slice(0, 10);
 
 const FONT_FILES = [
     '@fontsource-variable/bricolage-grotesque/files/bricolage-grotesque-latin-standard-normal.woff2',
@@ -29,6 +47,9 @@ if (!existsSync(join(ROOT, 'src/data/consumer-domains.ts'))) {
 }
 
 rmSync(DIST, { recursive: true, force: true });
+mkdirSync(DIST, { recursive: true });
+
+// ---- 1. Bundle TypeScript -------------------------------------------------
 
 console.log('Bundling TypeScript…');
 const build = await Bun.build({
@@ -39,16 +60,27 @@ const build = await Bun.build({
     target: 'browser',
     naming: '[name].js',
 });
-
 if (!build.success) {
     console.error('Build failed:');
     for (const log of build.logs) console.error(log);
     process.exit(1);
 }
 
-const html = readFileSync(HTML, 'utf8').replaceAll('{{YEAR}}', String(new Date().getFullYear()));
-writeFileSync(join(DIST, 'index.html'), html);
+// ---- 2. Static assets -----------------------------------------------------
+
 if (existsSync(PUBL)) cpSync(PUBL, DIST, { recursive: true });
+
+mkdirSync(join(DIST, 'fonts'), { recursive: true });
+for (const rel of FONT_FILES) {
+    const src = join(NM, rel);
+    if (!existsSync(src)) {
+        console.error(`Missing font file: ${rel} — did you run \`bun install\`?`);
+        process.exit(1);
+    }
+    cpSync(src, join(DIST, 'fonts', rel.split('/').pop()!));
+}
+
+// ---- 3. Tailwind ----------------------------------------------------------
 
 console.log('Compiling Tailwind…');
 const tw = Bun.spawnSync({
@@ -62,15 +94,262 @@ if (tw.exitCode !== 0) {
     process.exit(1);
 }
 
-mkdirSync(join(DIST, 'fonts'), { recursive: true });
-for (const rel of FONT_FILES) {
-    const src = join(NM, rel);
-    if (!existsSync(src)) {
-        console.error(`Missing font file: ${rel} — did you run \`bun install\`?`);
+// ---- 4. Page rendering ----------------------------------------------------
+
+const TEMPLATE = readFileSync(HTML, 'utf8');
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function render(vars: Record<string, string>): string {
+    let html = TEMPLATE;
+    for (const [k, v] of Object.entries(vars)) html = html.replaceAll(`{{${k}}}`, v);
+    html = html.replaceAll('{{YEAR}}', YEAR);
+    return html;
+}
+
+const PUBLISHER_LD = {
+    '@type': 'Organization',
+    '@id': `${SITE_ORIGIN}/#publisher`,
+    name: 'Email Service Checker',
+    url: SITE_ORIGIN,
+    logo: {
+        '@type': 'ImageObject',
+        url: `${SITE_ORIGIN}/logo.webp`,
+    },
+};
+
+const HOMEPAGE_LD = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+        PUBLISHER_LD,
+        {
+            '@type': 'WebSite',
+            '@id': `${SITE_ORIGIN}/#website`,
+            url: SITE_ORIGIN,
+            name: 'Email Service Checker',
+            publisher: { '@id': `${SITE_ORIGIN}/#publisher` },
+            inLanguage: 'en',
+            potentialAction: {
+                '@type': 'SearchAction',
+                target: {
+                    '@type': 'EntryPoint',
+                    urlTemplate: `${SITE_ORIGIN}/?domain={domain}`,
+                },
+                'query-input': 'required name=domain',
+            },
+        },
+    ],
+});
+
+function providerJsonLd(p: Provider): string {
+    const slug = providerSlug(p);
+    const url = `${SITE_ORIGIN}/provider/${slug}/`;
+    return JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+            PUBLISHER_LD,
+            {
+                '@type': 'BreadcrumbList',
+                itemListElement: [
+                    { '@type': 'ListItem', position: 1, name: 'Email Service Checker', item: `${SITE_ORIGIN}/` },
+                    { '@type': 'ListItem', position: 2, name: p.name, item: url },
+                ],
+            },
+            {
+                '@type': 'WebPage',
+                '@id': `${url}#webpage`,
+                url,
+                name: `${p.name} — ${CATEGORY_LABEL[p.category]}`,
+                description: describeProvider(p),
+                inLanguage: 'en',
+                isPartOf: { '@id': `${SITE_ORIGIN}/#website` },
+                publisher: { '@id': `${SITE_ORIGIN}/#publisher` },
+                about: {
+                    '@type': 'Organization',
+                    name: p.name,
+                    ...(p.url ? { url: p.url, sameAs: p.url } : {}),
+                },
+            },
+        ],
+    });
+}
+
+const CATEGORY_DESCRIPTION: Record<Provider['category'], string> = {
+    mailbox:   "A mailbox provider runs the inboxes where people read and send mail. Domains that point their MX records here have their email hosted directly by this service.",
+    consumer:  "Consumer mailbox services run personal email accounts. A domain whose MX records point here is using the provider's free or low-cost mailbox.",
+    gateway:   "A security gateway sits in front of the real mailbox to filter spam, phishing, and malware before mail reaches its destination. Inspection alone cannot tell you which mailbox provider sits behind it.",
+    forwarder: "A forwarder accepts mail at one address and re-sends it to another. The final mailbox is invisible from MX records alone — the forwarder is just a relay.",
+    relay:     "An inbound relay accepts mail over SMTP and hands it off to an application via API or webhook. There is no human inbox at the other end.",
+    parking:   "Domain-parking and aftermarket services publish MX records that point at black-hole servers. Mail sent to a parked domain is almost always silently discarded.",
+};
+
+function categoryArticle(c: Provider['category']): string {
+    return /^[aeiou]/i.test(CATEGORY_LABEL[c]) ? 'an' : 'a';
+}
+
+function describeProvider(p: Provider): string {
+    const label = CATEGORY_LABEL[p.category].toLowerCase();
+    return `${p.name} is ${categoryArticle(p.category)} ${label}. Its mail servers' hostnames end in ${p.matchers.map(m => `.${m}`).join(', ')}.`;
+}
+
+function relatedProviders(p: Provider, limit = 8): Provider[] {
+    return PROVIDERS
+        .filter(o => o.category === p.category && o.name !== p.name)
+        .slice(0, limit);
+}
+
+function profileSection(p: Provider): string {
+    const slug = providerSlug(p);
+    const related = relatedProviders(p);
+    const matchersList = p.matchers
+        .map(m => `<li class="font-mono text-text">·&nbsp;&nbsp;<code class="break-all">.${escapeHtml(m)}</code></li>`)
+        .join('');
+    const relatedList = related.length
+        ? `<div class="flex flex-col gap-2">
+                <p class="eyebrow">Other ${escapeHtml(CATEGORY_LABEL[p.category].toLowerCase())}s</p>
+                <ul class="flex flex-wrap gap-2">
+                    ${related.map(r => `<li><a class="btn-ghost text-xs" href="/provider/${providerSlug(r)}/">${escapeHtml(r.name)}</a></li>`).join('')}
+                </ul>
+            </div>`
+        : '';
+    return `
+        <section class="card p-6 sm:p-8 flex flex-col gap-6" data-provider="${escapeHtml(slug)}" itemscope itemtype="https://schema.org/Organization">
+            ${p.url ? `<link itemprop="sameAs" href="${escapeHtml(p.url)}">` : ''}
+            <div class="flex items-start justify-between gap-3">
+                <div class="flex flex-col gap-1 min-w-0">
+                    <p class="eyebrow">Provider profile</p>
+                    <h2 class="display-name break-words" itemprop="name">${escapeHtml(p.name)}</h2>
+                </div>
+                <span class="cat-badge cat-${p.category}">${escapeHtml(CATEGORY_LABEL[p.category])}</span>
+            </div>
+
+            <p class="text-subtext-1" itemprop="description">${escapeHtml(describeProvider(p))}</p>
+
+            <div class="flex flex-col gap-2">
+                <p class="eyebrow">What is ${categoryArticle(p.category)} ${escapeHtml(CATEGORY_LABEL[p.category].toLowerCase())}?</p>
+                <p class="text-subtext-1 text-[0.95rem]">${escapeHtml(CATEGORY_DESCRIPTION[p.category])}</p>
+            </div>
+
+            <div class="flex flex-col gap-2">
+                <p class="eyebrow">MX hostname patterns</p>
+                <ul class="flex flex-col gap-1 text-sm">${matchersList}</ul>
+            </div>
+
+            ${p.url ? `<p class="text-sm"><a href="${escapeHtml(p.url)}" target="_blank" rel="noopener">Official site →</a></p>` : ''}
+
+            ${relatedList}
+
+            <p class="text-sm text-subtext-0 pt-4 border-t border-crust">
+                Want to inspect a different domain? Use the form above, or <a href="/">go back to the homepage</a>.
+            </p>
+        </section>`;
+}
+
+function breadcrumbHtml(items: Array<{ name: string; href?: string }>): string {
+    const parts = items.map((it, i) => {
+        const isLast = i === items.length - 1;
+        const inner = isLast
+            ? `<span aria-current="page">${escapeHtml(it.name)}</span>`
+            : `<a href="${escapeHtml(it.href ?? '/')}" class="hover:text-text">${escapeHtml(it.name)}</a>`;
+        return `<li>${inner}</li>`;
+    });
+    return `<nav aria-label="Breadcrumb" class="w-full">
+        <ol class="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-subtext-0 text-xs">
+            ${parts.join('<li aria-hidden="true" class="text-surface-1">/</li>')}
+        </ol>
+    </nav>`;
+}
+
+// ---- 5. Emit homepage -----------------------------------------------------
+
+writeFileSync(join(DIST, 'index.html'), render({
+    TITLE: 'Email Service Checker — Find Email Providers',
+    DESCRIPTION: 'Find out who runs the email for any domain. Detects Google Workspace, Microsoft 365, Proton, Apple, Yahoo, Fastmail, Zoho, and over 160 other providers.',
+    CANONICAL: `${SITE_ORIGIN}/`,
+    OG_TITLE: 'Email Service Checker — Find Email Providers',
+    OG_DESCRIPTION: "Type a domain. We'll tell you which service is running its email.",
+    JSON_LD: HOMEPAGE_LD,
+    BREADCRUMBS: '',
+    HERO_EYEBROW: 'Email provider finder',
+    HERO_TITLE: "What's <em>actually</em> handling the mail?",
+    HERO_LEDE: "Type a domain or email address. We'll tell you which service is running its email — Google, Microsoft, Proton, Apple, and 160+ others.",
+    PROFILE_SECTION: '',
+}));
+
+// ---- 6. Emit per-provider pages ------------------------------------------
+
+const seen = new Set<string>();
+for (const p of PROVIDERS) {
+    const slug = providerSlug(p);
+    if (seen.has(slug)) {
+        console.error(`Slug collision: ${slug} (provider "${p.name}")`);
         process.exit(1);
     }
-    cpSync(src, join(DIST, 'fonts', rel.split('/').pop()!));
+    seen.add(slug);
+
+    const dir = join(DIST, 'provider', slug);
+    mkdirSync(dir, { recursive: true });
+    const title = `${p.name} — ${CATEGORY_LABEL[p.category]} | Email Service Checker`;
+    writeFileSync(join(dir, 'index.html'), render({
+        TITLE: title,
+        DESCRIPTION: `${describeProvider(p)} Check whether any domain uses it.`,
+        CANONICAL: `${SITE_ORIGIN}/provider/${slug}/`,
+        OG_TITLE: `${p.name} — ${CATEGORY_LABEL[p.category]}`,
+        OG_DESCRIPTION: describeProvider(p),
+        JSON_LD: providerJsonLd(p),
+        BREADCRUMBS: breadcrumbHtml([
+            { name: 'Home', href: '/' },
+            { name: p.name },
+        ]),
+        HERO_EYEBROW: escapeHtml(CATEGORY_LABEL[p.category]),
+        HERO_TITLE: escapeHtml(p.name),
+        HERO_LEDE: `${p.name} is ${categoryArticle(p.category)} ${CATEGORY_LABEL[p.category].toLowerCase()}. Type any domain below to see if its email runs through ${p.name}.`,
+        PROFILE_SECTION: profileSection(p),
+    }));
 }
+
+// ---- 7. Sitemap + robots --------------------------------------------------
+
+const sitemapUrls = [
+    { loc: `${SITE_ORIGIN}/`,                 priority: '1.0', change: 'weekly' },
+    ...PROVIDERS.map(p => ({
+        loc: `${SITE_ORIGIN}/provider/${providerSlug(p)}/`,
+        priority: '0.7',
+        change: 'monthly',
+    })),
+];
+
+writeFileSync(
+    join(DIST, 'sitemap.xml'),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${sitemapUrls.map(u => `    <url>
+        <loc>${u.loc}</loc>
+        <lastmod>${TODAY}</lastmod>
+        <changefreq>${u.change}</changefreq>
+        <priority>${u.priority}</priority>
+    </url>`).join('\n')}
+</urlset>
+`,
+);
+
+writeFileSync(
+    join(DIST, 'robots.txt'),
+    `User-agent: *
+Allow: /
+
+Sitemap: ${SITE_ORIGIN}/sitemap.xml
+`,
+);
+
+// ---- 8. Stats + dev server ------------------------------------------------
 
 const total = readdirSync(DIST, { recursive: true })
     .map(f => {
@@ -78,7 +357,7 @@ const total = readdirSync(DIST, { recursive: true })
     })
     .reduce((a, b) => a + b, 0);
 
-console.log(`Built ${(total / 1024).toFixed(1)} kB → ${DIST}`);
+console.log(`Built ${(total / 1024).toFixed(1)} kB — ${PROVIDERS.length} provider pages + sitemap → ${DIST}`);
 
 if (serve) {
     const port = Number(process.env.PORT ?? 3000);
@@ -86,10 +365,12 @@ if (serve) {
         port,
         async fetch(req) {
             const url = new URL(req.url);
-            const path = url.pathname === '/' ? '/index.html' : url.pathname;
+            let path = url.pathname;
+            if (path.endsWith('/')) path += 'index.html';
             const file = Bun.file(join(DIST, path));
             if (await file.exists()) return new Response(file);
-            return new Response('Not found', { status: 404 });
+            // Fallback: serve homepage with 404 status for unknown paths
+            return new Response(Bun.file(join(DIST, 'index.html')), { status: 404 });
         },
     });
     console.log(`Serving at http://localhost:${port}`);

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,5 +1,12 @@
 import type { Provider, ProviderCategory } from './types.ts';
 
+export function providerSlug(provider: Pick<Provider, 'name'>): string {
+    return provider.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
 // Each provider lists MX hostname suffixes that uniquely identify it.
 // Matching is done by exact-host or dot-suffix match in identify.ts —
 // so "mail.com" will not match "googlemail.com". Longest matcher wins,

--- a/src/render.ts
+++ b/src/render.ts
@@ -25,18 +25,22 @@ function reportNumber(domain: string): string {
     return (h >>> 0).toString(36).toUpperCase().padStart(7, '0').slice(0, 7);
 }
 
-const REPORT_CARD = 'paper-card report-card grid gap-[1.2rem] p-[clamp(1.25rem,3.5vw,2rem)]';
+const CARD = 'card report-anim p-6 sm:p-8 flex flex-col';
+
+function categoryBadge(category: Finding['provider']['category']): HTMLElement {
+    return el('span', { class: `cat-badge cat-${category}` }, CATEGORY_LABEL[category]);
+}
 
 function mxTable(mxRecords: readonly MxRecord[]): HTMLElement {
-    const wrap = el('div', { class: 'grid gap-[0.6rem] pt-[0.9rem] border-t border-dashed border-rule' });
-    wrap.append(el('div', { class: 'stencil' }, 'Evidence — MX records'));
-    const table = el('table', { class: 'w-full border-collapse font-mono text-[0.84rem]' });
+    const wrap = el('div', { class: 'report-row flex flex-col gap-3' });
+    wrap.append(el('p', { class: 'eyebrow' }, `Evidence — ${mxRecords.length} MX record${mxRecords.length === 1 ? '' : 's'}`));
+    const table = el('table', { class: 'mx-table' });
     const tbody = el('tbody');
     for (const mx of mxRecords) {
         tbody.append(
             el('tr', {},
-                el('td', { class: 'py-1 pr-4 w-[3.2rem] text-end align-top text-ink-faded border-b border-dotted border-rule-soft' }, String(mx.priority)),
-                el('td', { class: 'py-1 pl-2 align-top text-ink break-all border-b border-dotted border-rule-soft' }, mx.host),
+                el('td', { class: 'mx-prio' }, String(mx.priority)),
+                el('td', { class: 'mx-host' }, mx.host),
             ),
         );
     }
@@ -53,7 +57,7 @@ function shareButton(domain: string): HTMLButtonElement {
         try {
             await navigator.clipboard.writeText(url.toString());
             btn.textContent = 'Link copied';
-            setTimeout(() => { btn.textContent = 'Copy share link'; }, 1600);
+            setTimeout(() => { btn.textContent = 'Copy share link'; }, 1500);
         } catch {
             btn.textContent = 'Copy failed';
         }
@@ -64,36 +68,29 @@ function shareButton(domain: string): HTMLButtonElement {
 function findingBlock(finding: Finding): HTMLElement {
     const { provider } = finding;
     const cat = provider.category;
-    const block = el('article', { class: 'finding' });
+    const block = el('div', { class: 'finding' });
 
-    block.append(el('div', { class: 'stencil' }, CATEGORY_LABEL[cat]));
-
-    const name = provider.url
-        ? el('a', { class: 'display-name', href: provider.url, target: '_blank', rel: 'noopener' }, provider.name)
-        : el('h3', { class: 'display-name' }, provider.name);
-    block.append(name);
-
-    block.append(
-        el('div', { class: `postmark postmark--${cat}` },
-            el('span', { class: 'postmark-arc' }, CATEGORY_LABEL[cat].toUpperCase()),
-        ),
-    );
+    const title = provider.url
+        ? el('a', { class: 'display-name finding-title', href: provider.url, target: '_blank', rel: 'noopener' }, provider.name)
+        : el('h3', { class: 'display-name finding-title' }, provider.name);
+    block.append(title);
+    block.append(el('div', { class: 'finding-badge' }, categoryBadge(cat)));
 
     const note = CATEGORY_NOTE[cat];
-    if (note) block.append(el('p', { class: 'text-ink-soft text-[0.92rem] max-w-[56ch]' }, note));
+    if (note) block.append(el('p', { class: 'finding-note' }, note));
 
     return block;
 }
 
 function consumerCallout(hit: ConsumerHit): HTMLElement {
-    const label = hit.kind === 'disposable' ? 'Disposable address service' : 'Free consumer mailbox';
+    const label = hit.kind === 'disposable' ? 'Disposable mailbox service' : 'Free consumer mailbox';
     const detail = hit.kind === 'disposable'
-        ? 'This domain is published as a temporary / throwaway mailbox provider — addresses on it are usually short-lived.'
-        : 'This domain is a free consumer email service. Mail sent here lands in a personal account, not a business mailbox.';
-    return el('article', { class: 'finding' },
-        el('div', { class: 'stencil' }, 'Catalogued in open dataset'),
-        el('h3', { class: 'display-name' }, label),
-        el('p', { class: 'text-ink-soft text-[0.92rem] max-w-[56ch]' }, detail),
+        ? 'This domain is published in the open disposable-mailbox catalogue — addresses on it are usually short-lived throwaways.'
+        : 'This domain is in the open free-mailbox catalogue. Mail sent here goes to a personal account, not a business mailbox.';
+    return el('div', { class: 'finding' },
+        el('h3', { class: 'display-name finding-title' }, label),
+        el('div', { class: 'finding-badge' }, el('span', { class: 'cat-badge cat-consumer' }, 'Open dataset')),
+        el('p', { class: 'finding-note' }, detail),
     );
 }
 
@@ -109,30 +106,26 @@ export function renderReport(target: HTMLElement, input: RenderInput): void {
 }
 
 function buildReport({ domain, findings, mxRecords, consumerHit }: RenderInput): HTMLElement {
-    const report = el('section', { class: REPORT_CARD, 'aria-live': 'polite' });
+    const report = el('section', { class: CARD, 'aria-live': 'polite' });
 
     report.append(
-        el('header', { class: 'flex justify-between gap-4 pb-[0.7rem] border-b border-rule stencil' },
-            el('span', {}, 'INSPECTION REPORT'),
-            el('span', { class: 'text-ink-soft' }, `N° ${reportNumber(domain)}`),
+        el('div', { class: 'report-row flex items-center justify-between gap-3' },
+            el('div', { class: 'flex flex-col min-w-0' },
+                el('span', { class: 'eyebrow mb-1' }, 'Subject'),
+                el('span', { class: 'font-mono text-[0.95rem] text-text break-all' }, domain),
+            ),
+            el('span', { class: 'eyebrow text-overlay-1' }, `N° ${reportNumber(domain)}`),
         ),
     );
 
-    report.append(
-        el('div', { class: 'grid gap-1' },
-            el('span', { class: 'stencil' }, 'Subject'),
-            el('span', { class: 'font-mono text-[clamp(1rem,2.6vw,1.15rem)] text-ink break-all' }, domain),
-        ),
-    );
-
-    const findingsWrap = el('div', { class: 'findings-list' });
+    const findingsWrap = el('div', { class: 'report-row flex flex-col gap-7' });
 
     if (findings.length === 0 && mxRecords.length > 0) {
         findingsWrap.append(
-            el('article', { class: 'finding' },
-                el('div', { class: 'stencil' }, 'Inconclusive'),
-                el('h3', { class: 'display-name' }, 'Unrecognised provider'),
-                el('p', { class: 'text-ink-soft text-[0.92rem] max-w-[56ch]' },
+            el('div', { class: 'finding' },
+                el('h3', { class: 'display-name finding-title' }, 'Unrecognised provider'),
+                el('div', { class: 'finding-badge' }, el('span', { class: 'cat-badge cat-parking' }, 'Inconclusive')),
+                el('p', { class: 'finding-note' },
                     'MX records were found, but none match a known provider in our catalogue. ',
                     el('a', {
                         href: `https://github.com/viktopia/email-service-checker/issues/new?title=${encodeURIComponent(`Add provider for ${domain}`)}`,
@@ -144,11 +137,11 @@ function buildReport({ domain, findings, mxRecords, consumerHit }: RenderInput):
         );
     } else if (mxRecords.length === 0) {
         findingsWrap.append(
-            el('article', { class: 'finding' },
-                el('div', { class: 'stencil' }, 'No mail exchange'),
-                el('h3', { class: 'display-name' }, 'No MX records'),
-                el('p', { class: 'text-ink-soft text-[0.92rem] max-w-[56ch]' },
-                    `${domain} publishes no MX records, so it almost certainly does not receive email at this domain.`),
+            el('div', { class: 'finding' },
+                el('h3', { class: 'display-name finding-title' }, 'No MX records'),
+                el('div', { class: 'finding-badge' }, el('span', { class: 'cat-badge cat-parking' }, 'No mail exchange')),
+                el('p', { class: 'finding-note' },
+                    `${domain} publishes no MX records, so it almost certainly does not receive email.`),
             ),
         );
     } else {
@@ -161,7 +154,7 @@ function buildReport({ domain, findings, mxRecords, consumerHit }: RenderInput):
     if (mxRecords.length > 0) report.append(mxTable(mxRecords));
 
     report.append(
-        el('footer', { class: 'pt-[0.7rem] border-t border-rule flex flex-wrap justify-end gap-2' },
+        el('div', { class: 'report-row flex justify-end' },
             shareButton(domain),
         ),
     );
@@ -170,8 +163,8 @@ function buildReport({ domain, findings, mxRecords, consumerHit }: RenderInput):
 
 export function renderError(target: HTMLElement, message: string): void {
     target.replaceChildren(
-        el('section', { class: `${REPORT_CARD} border-stamp-red`, 'aria-live': 'polite' },
-            el('div', { class: 'stencil text-stamp-red' }, 'Lookup failed'),
+        el('section', { class: `${CARD} border-red`, 'aria-live': 'polite' },
+            el('p', { class: 'eyebrow text-red mb-2' }, 'Lookup failed'),
             el('h3', { class: 'display-name' }, message),
         ),
     );
@@ -179,11 +172,11 @@ export function renderError(target: HTMLElement, message: string): void {
 
 export function renderLoading(target: HTMLElement, domain: string): void {
     target.replaceChildren(
-        el('section', { class: REPORT_CARD, 'aria-live': 'polite' },
-            el('div', { class: 'stencil' }, 'Querying DNS'),
-            el('h3', { class: 'display-name text-ink-faded' },
+        el('section', { class: CARD, 'aria-live': 'polite' },
+            el('p', { class: 'eyebrow mb-2' }, 'Querying DNS'),
+            el('h3', { class: 'display-name text-overlay-1' },
                 'Resolving ',
-                el('span', { class: 'font-mono' }, domain),
+                el('span', { class: 'font-mono text-text' }, domain),
                 el('span', { class: 'cursor' }, '_'),
             ),
         ),

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,66 +1,71 @@
 @import "tailwindcss";
 
-/* Tell Tailwind where to look for class names (it scans these files at build). */
 @source "../index.html";
 @source "./**/*.ts";
 
 /* ============================================================================
- *  Design tokens — exposed as Tailwind utilities through @theme.
- *  Every color and font in this codebase routes through these vars, so the
- *  HTML/TS stay declarative (e.g. `bg-paper text-ink font-display`).
+ *  Design tokens — Catppuccin Latte palette.
+ *  https://github.com/catppuccin/catppuccin#-palette
  * ========================================================================= */
 
 @theme {
-    /* Paper & ink (OKLCH for perceptual uniformity) */
-    --color-paper:        oklch(96.5% 0.018 80);
-    --color-paper-warm:   oklch(94.5% 0.024 78);
-    --color-paper-edge:   oklch(86%   0.030 75);
-    --color-rule:         oklch(72%   0.030 70 / 0.55);
-    --color-rule-soft:    oklch(72%   0.030 70 / 0.25);
+    /* Surfaces (light → dark) */
+    --color-base:      #eff1f5;
+    --color-mantle:    #e6e9ef;
+    --color-crust:     #dce0e8;
+    --color-surface-0: #ccd0da;
+    --color-surface-1: #bcc0cc;
+    --color-surface-2: #acb0be;
 
-    --color-ink:          oklch(22%   0.040 250);
-    --color-ink-soft:     oklch(38%   0.028 250);
-    --color-ink-faded:    oklch(58%   0.022 250);
+    /* Overlays (subdued chrome) */
+    --color-overlay-0: #9ca0b0;
+    --color-overlay-1: #8c8fa1;
+    --color-overlay-2: #7c7f93;
 
-    /* Postmark accents */
-    --color-stamp-red:    oklch(56%   0.180  30);
-    --color-stamp-blue:   oklch(45%   0.130 255);
-    --color-mustard:      oklch(72%   0.140  82);
-    --color-moss:         oklch(52%   0.090 145);
-    --color-plum:         oklch(48%   0.130 320);
+    /* Text (faint → strong) */
+    --color-subtext-0: #6c6f85;
+    --color-subtext-1: #5c5f77;
+    --color-text:      #4c4f69;
 
-    /* Type stack — self-hosted via @fontsource-variable */
-    --font-display: 'Fraunces', 'Times New Roman', serif;
-    --font-body:    'Figtree', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    /* Accents */
+    --color-rosewater: #dc8a78;
+    --color-flamingo:  #dd7878;
+    --color-pink:      #ea76cb;
+    --color-mauve:     #8839ef;
+    --color-red:       #d20f39;
+    --color-maroon:    #e64553;
+    --color-peach:     #fe640b;
+    --color-yellow:    #df8e1d;
+    --color-green:     #40a02b;
+    --color-teal:      #179299;
+    --color-sky:       #04a5e5;
+    --color-sapphire:  #209fb5;
+    --color-blue:      #1e66f5;
+    --color-lavender:  #7287fd;
+
+    --font-display: 'Bricolage Grotesque', system-ui, sans-serif;
+    --font-body:    'Onest', system-ui, -apple-system, 'Segoe UI', sans-serif;
     --font-mono:    'JetBrains Mono', ui-monospace, 'Menlo', monospace;
 
-    /* Geometry */
-    --radius-card: 2px;
-    --tracking-stencil: 0.22em;
+    --radius-card: 16px;
+    --radius-pill: 9999px;
 }
 
-/* ---- Self-hosted fonts (copied from node_modules by scripts/build.ts) -- */
+/* ---- Self-hosted fonts ----------------------------------------------- */
 
 @font-face {
-    font-family: 'Fraunces';
+    font-family: 'Bricolage Grotesque';
+    font-style: normal;
+    font-display: swap;
+    font-weight: 200 800;
+    src: url('fonts/bricolage-grotesque-latin-standard-normal.woff2') format('woff2-variations');
+}
+@font-face {
+    font-family: 'Onest';
     font-style: normal;
     font-display: swap;
     font-weight: 100 900;
-    src: url('fonts/fraunces-latin-full-normal.woff2') format('woff2-variations');
-}
-@font-face {
-    font-family: 'Fraunces';
-    font-style: italic;
-    font-display: swap;
-    font-weight: 100 900;
-    src: url('fonts/fraunces-latin-full-italic.woff2') format('woff2-variations');
-}
-@font-face {
-    font-family: 'Figtree';
-    font-style: normal;
-    font-display: swap;
-    font-weight: 300 900;
-    src: url('fonts/figtree-latin-wght-normal.woff2') format('woff2-variations');
+    src: url('fonts/onest-latin-wght-normal.woff2') format('woff2-variations');
 }
 @font-face {
     font-family: 'JetBrains Mono';
@@ -70,269 +75,257 @@
     src: url('fonts/jetbrains-mono-latin-wght-normal.woff2') format('woff2-variations');
 }
 
-/* ---- Base layer (page chrome) ----------------------------------------- */
+/* ---- Base layer ----------------------------------------------------- */
 
 @layer base {
-    :root { color-scheme: light; accent-color: var(--color-stamp-red); }
+    :root { color-scheme: light; accent-color: var(--color-blue); }
 
     html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 
     body {
         min-block-size: 100dvh;
         font-family: var(--font-body);
-        font-feature-settings: 'ss02' on;
-        color: var(--color-ink);
-        background:
-            radial-gradient(ellipse at 20% 0%,  oklch(98% 0.012 80)  0%, transparent 55%),
-            radial-gradient(ellipse at 80% 100%, oklch(92% 0.030 70) 0%, transparent 60%),
-            var(--color-paper);
-        background-attachment: fixed;
+        font-size: 16px;
+        line-height: 1.55;
+        color: var(--color-text);
+        background: var(--color-base);
         display: grid;
-        grid-template-rows: auto 1fr auto;
+        grid-template-rows: 1fr auto;
     }
 
-    /* Paper grain — SVG noise via data URI, zero asset bytes. */
+    /* Subtle gradient mesh — calmer than a flat fill, no noise overlay. */
     body::before {
         content: '';
         position: fixed;
         inset: 0;
         pointer-events: none;
-        opacity: 0.4;
-        mix-blend-mode: multiply;
         z-index: 0;
-        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.16 0 0 0 0 0.15 0 0 0 0 0.18 0 0 0 0 0.18 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+        background:
+            radial-gradient(60rem 40rem at 12% -10%, color-mix(in oklab, var(--color-lavender) 22%, transparent), transparent 70%),
+            radial-gradient(50rem 38rem at 110% 110%, color-mix(in oklab, var(--color-teal) 18%, transparent),   transparent 70%);
     }
 
-    a { color: var(--color-stamp-blue); text-underline-offset: 0.18em; }
-    a:hover { color: var(--color-stamp-red); }
+    a { color: var(--color-blue); text-decoration: none; text-underline-offset: 0.18em; }
+    a:hover { text-decoration: underline; }
+
+    :focus-visible {
+        outline: 2px solid var(--color-blue);
+        outline-offset: 2px;
+        border-radius: 4px;
+    }
 }
 
-/* ---- Components ------------------------------------------------------- */
-/* These pieces are genuinely custom design (rotated postmark badges,
- * paper-card double rules, container-query layout) — not utility-soup
- * candidates. They reference the same @theme tokens, so changing a color
- * propagates through every component. */
+/* ---- Components ----------------------------------------------------- */
 
 @layer components {
 
-    /* The paper-card chrome shared by the form and the report */
-    .paper-card {
-        position: relative;
-        background: var(--color-paper);
-        border: 1px solid var(--color-paper-edge);
+    .card {
+        background: color-mix(in oklab, var(--color-mantle) 80%, white);
+        border: 1px solid var(--color-crust);
         border-radius: var(--radius-card);
         box-shadow:
-            inset 0 0 0 1px oklch(100% 0 0 / 0.45),
-            0 1px 0 0 oklch(100% 0 0 / 0.55),
-            0 30px 50px -32px oklch(20% 0.04 250 / 0.35);
-    }
-    .paper-card--warm { background: var(--color-paper-warm); }
-    .paper-card::before,
-    .paper-card::after {
-        content: '';
-        position: absolute;
-        inset-inline: 8px;
-        block-size: 1px;
-        background: var(--color-rule);
-        opacity: 0.6;
-    }
-    .paper-card::before { inset-block-start: 5px; }
-    .paper-card::after  { inset-block-end: 5px; }
-
-    /* Section caption — small mono uppercase stencil */
-    .stencil {
-        font-family: var(--font-mono);
-        font-size: 0.68rem;
-        letter-spacing: var(--tracking-stencil);
-        text-transform: uppercase;
-        color: var(--color-ink-faded);
+            0 1px 0 0 color-mix(in oklab, white 60%, transparent),
+            0 1px 2px 0 color-mix(in oklab, var(--color-subtext-1) 8%, transparent),
+            0 20px 40px -28px color-mix(in oklab, var(--color-subtext-1) 35%, transparent);
     }
 
-    /* Display headline with the Fraunces SOFT axis turned up */
-    .display-title {
+    .display-hero {
         font-family: var(--font-display);
-        font-optical-sizing: auto;
-        font-variation-settings: 'opsz' 144, 'SOFT' 30, 'wght' 600;
-        font-style: italic;
-        font-size: clamp(2.25rem, 6.5vw, 3.5rem);
-        line-height: 1.02;
-        letter-spacing: -0.015em;
-        color: var(--color-ink);
+        font-variation-settings: 'wdth' 100, 'wght' 700, 'opsz' 96;
+        font-size: clamp(2rem, 5.5vw + 0.5rem, 3.25rem);
+        line-height: 1.05;
+        letter-spacing: -0.025em;
+        color: var(--color-text);
         text-wrap: balance;
     }
-    .display-title em {
-        font-style: italic;
-        color: var(--color-stamp-red);
-        font-variation-settings: 'opsz' 144, 'SOFT' 100, 'wght' 600;
+    .display-hero em {
+        font-style: normal;
+        font-variation-settings: 'wdth' 96, 'wght' 700, 'opsz' 96;
+        color: var(--color-blue);
     }
+
     .display-name {
         font-family: var(--font-display);
-        font-variation-settings: 'opsz' 96, 'SOFT' 40, 'wght' 600;
-        font-size: clamp(1.6rem, 4.5vw, 2.15rem);
-        line-height: 1.05;
-        letter-spacing: -0.015em;
-        color: var(--color-ink);
+        font-variation-settings: 'wdth' 100, 'wght' 700, 'opsz' 36;
+        font-size: clamp(1.5rem, 1.1rem + 1.4vw, 2rem);
+        line-height: 1.1;
+        letter-spacing: -0.02em;
+        color: var(--color-text);
         text-decoration: none;
     }
-    a.display-name:hover { color: var(--color-stamp-red); }
+    a.display-name { transition: color 160ms ease; }
+    a.display-name:hover { color: var(--color-blue); text-decoration: none; }
 
-    /* Variable-axis input — Fraunces with opsz=36 */
-    .input-display {
-        inline-size: 100%;
-        padding: 0.9rem 0.25rem;
-        background: transparent;
-        border: 0;
-        border-block-end: 1.5px solid var(--color-ink-soft);
-        border-radius: 0;
-        color: var(--color-ink);
-        font-family: var(--font-display);
-        font-variation-settings: 'opsz' 36, 'SOFT' 100, 'wght' 500;
-        font-size: clamp(1.15rem, 3vw, 1.4rem);
-        letter-spacing: -0.01em;
-        transition: border-color 180ms ease;
+    .eyebrow {
+        font-family: var(--font-mono);
+        font-size: 0.72rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-subtext-0);
     }
-    .input-display::placeholder { color: var(--color-ink-faded); font-style: italic; }
-    .input-display:focus {
+
+    /* Input + button — share the same height + radius so they line up */
+    .field-input {
+        block-size: 3.25rem;
+        inline-size: 100%;
+        padding-inline: 1rem;
+        background: white;
+        border: 1px solid var(--color-surface-0);
+        border-radius: 12px;
+        color: var(--color-text);
+        font-family: var(--font-body);
+        font-size: 1rem;
+        font-weight: 500;
+        transition: border-color 180ms ease, box-shadow 180ms ease;
+    }
+    .field-input::placeholder { color: var(--color-overlay-1); }
+    .field-input:focus {
         outline: none;
-        border-block-end-color: var(--color-stamp-red);
+        border-color: var(--color-blue);
+        box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-blue) 18%, transparent);
     }
 
-    /* Primary action — uppercase tracked, with sliding arrow */
-    .btn-stencil {
-        appearance: none;
-        inline-size: 100%;
-        padding-inline: 1.4rem;
-        padding-block: 0.9rem;
-        background: var(--color-ink);
-        color: var(--color-paper);
+    .btn-primary {
+        block-size: 3.25rem;
+        padding-inline: 1.5rem;
+        background: var(--color-blue);
+        color: white;
         font-family: var(--font-body);
         font-weight: 600;
-        font-size: 0.78rem;
-        letter-spacing: var(--tracking-stencil);
-        text-transform: uppercase;
-        border-radius: var(--radius-card);
+        font-size: 0.95rem;
+        letter-spacing: -0.005em;
+        border-radius: 12px;
         cursor: pointer;
-        transition: transform 120ms ease, background 180ms ease;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        white-space: nowrap;
+        transition: background 160ms ease, transform 120ms ease;
     }
-    .btn-stencil:hover { background: var(--color-stamp-red); }
-    .btn-stencil:active { transform: translateY(1px); }
-    .btn-stencil[disabled] { opacity: 0.55; cursor: progress; }
-    .btn-stencil::after {
-        content: '→';
-        margin-inline-start: 0.55rem;
-        display: inline-block;
-        transition: transform 200ms ease;
-    }
-    .btn-stencil:hover::after { transform: translateX(4px); }
-    .is-busy .btn-stencil::after { content: '...'; margin-inline-start: 0.35rem; }
+    .btn-primary:hover  { background: color-mix(in oklab, var(--color-blue) 88%, black); }
+    .btn-primary:active { transform: translateY(1px); }
+    .btn-primary[disabled] { opacity: 0.6; cursor: progress; }
 
     .btn-ghost {
-        font-family: var(--font-mono);
-        font-size: 0.7rem;
-        letter-spacing: 0.18em;
-        text-transform: uppercase;
-        padding: 0.55rem 0.9rem;
-        color: var(--color-ink-soft);
+        block-size: 2.25rem;
+        padding-inline: 0.85rem;
         background: transparent;
-        border: 1px solid var(--color-rule);
-        border-radius: var(--radius-card);
+        color: var(--color-subtext-1);
+        font-family: var(--font-body);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: 1px solid var(--color-surface-0);
+        border-radius: 8px;
         cursor: pointer;
-        transition: color 160ms ease, border-color 160ms ease, background 160ms ease;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        transition: color 160ms, border-color 160ms, background 160ms;
     }
     .btn-ghost:hover {
-        color: var(--color-paper);
-        background: var(--color-ink);
-        border-color: var(--color-ink);
+        color: var(--color-text);
+        border-color: var(--color-surface-2);
+        background: color-mix(in oklab, var(--color-mantle) 60%, white);
     }
 
-    /* Postmark badge — rotated circle with dashed inner ring */
-    .postmark {
-        --pm-color: var(--color-ink-soft);
-        inline-size: 96px;
-        block-size: 96px;
-        border: 1.5px solid currentColor;
-        border-radius: 50%;
-        color: var(--pm-color);
-        display: grid;
-        place-items: center;
-        rotate: -8deg;
-        opacity: 0.85;
-        justify-self: end;
-        position: relative;
-        flex-shrink: 0;
-    }
-    .postmark::before {
-        content: '';
-        position: absolute;
-        inset: 6px;
-        border: 1px dashed currentColor;
-        border-radius: 50%;
-        opacity: 0.5;
-    }
-    .postmark-arc {
-        font-family: var(--font-mono);
-        font-size: 0.55rem;
-        font-weight: 700;
-        letter-spacing: 0.18em;
-        text-align: center;
-        text-transform: uppercase;
-        max-inline-size: 70px;
-        line-height: 1.15;
-    }
-    .postmark--mailbox   { --pm-color: var(--color-moss);       }
-    .postmark--consumer  { --pm-color: var(--color-stamp-blue); }
-    .postmark--gateway   { --pm-color: var(--color-stamp-red);  }
-    .postmark--forwarder { --pm-color: var(--color-plum);       }
-    .postmark--relay     { --pm-color: var(--color-mustard);    }
-    .postmark--parking   { --pm-color: var(--color-ink-faded);  }
-
-    /* Container-query layout for findings so they restack on narrow widths */
-    .findings-list {
-        container-type: inline-size;
-        display: grid;
-        gap: 1.1rem;
-    }
-    .finding {
-        position: relative;
-        padding-block: 0.9rem;
-        border-block-start: 1px solid var(--color-rule-soft);
-        display: grid;
+    /* Category badge — capsule pill with palette accent */
+    .cat-badge {
+        display: inline-flex;
+        align-items: center;
         gap: 0.4rem;
-        grid-template-columns: 1fr;
+        block-size: 1.5rem;
+        padding-inline: 0.7rem;
+        font-family: var(--font-body);
+        font-size: 0.72rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        border-radius: var(--radius-pill);
+        background: color-mix(in oklab, var(--cat-color, var(--color-overlay-1)) 15%, white);
+        color: color-mix(in oklab, var(--cat-color, var(--color-overlay-1)) 75%, var(--color-text));
+        border: 1px solid color-mix(in oklab, var(--cat-color, var(--color-overlay-1)) 30%, transparent);
+        white-space: nowrap;
     }
-    .finding:first-child { border-block-start: 0; padding-block-start: 0; }
-    @container (min-width: 32rem) {
-        .finding { grid-template-columns: 1fr auto; column-gap: 1.5rem; }
-        .finding .postmark { grid-row: span 3; align-self: center; }
+    .cat-badge::before {
+        content: '';
+        inline-size: 0.4rem;
+        block-size: 0.4rem;
+        border-radius: 50%;
+        background: var(--cat-color, var(--color-overlay-1));
     }
 
-    /* Report card entrance */
-    .report-card { animation: report-rise 380ms cubic-bezier(0.2, 0.7, 0.2, 1) both; }
-    @keyframes report-rise {
-        from { opacity: 0; transform: translateY(8px); }
+    .cat-mailbox   { --cat-color: var(--color-green);    }
+    .cat-consumer  { --cat-color: var(--color-blue);     }
+    .cat-gateway   { --cat-color: var(--color-red);      }
+    .cat-forwarder { --cat-color: var(--color-mauve);    }
+    .cat-relay     { --cat-color: var(--color-peach);    }
+    .cat-parking   { --cat-color: var(--color-overlay-1);}
+
+    /* Finding row — explicit grid so headline / badge / note all align */
+    .finding {
+        display: grid;
+        gap: 0.5rem 1rem;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: baseline;
+    }
+    .finding-title    { grid-column: 1; }
+    .finding-badge    { grid-column: 2; align-self: center; }
+    .finding-note     { grid-column: 1 / -1; color: var(--color-subtext-0); font-size: 0.92rem; max-inline-size: 60ch; }
+
+    .report-row {
+        padding-block: 1.25rem;
+        border-block-start: 1px solid var(--color-crust);
+    }
+    .report-row:first-child { border-block-start: 0; padding-block-start: 0; }
+    .report-row:last-child  { padding-block-end: 0; }
+
+    .mx-table {
+        inline-size: 100%;
+        border-collapse: collapse;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        font-variation-settings: 'wght' 400;
+        color: var(--color-text);
+    }
+    .mx-table td {
+        padding-block: 0.4rem;
+        vertical-align: top;
+        border-block-end: 1px solid color-mix(in oklab, var(--color-crust) 60%, transparent);
+    }
+    .mx-table tr:last-child td { border-block-end: 0; }
+    .mx-prio {
+        inline-size: 3rem;
+        padding-inline-end: 1rem;
+        text-align: end;
+        color: var(--color-overlay-1);
+    }
+    .mx-host { word-break: break-all; }
+
+    .report-anim { animation: rise 320ms cubic-bezier(0.2, 0.7, 0.2, 1) both; }
+    @keyframes rise {
+        from { opacity: 0; transform: translateY(6px); }
         to   { opacity: 1; transform: translateY(0); }
     }
 
-    /* Loading cursor */
-    .cursor { display: inline-block; inline-size: 0.5ch; animation: blink 1s steps(2, end) infinite; }
+    .cursor {
+        display: inline-block;
+        inline-size: 0.4ch;
+        margin-inline-start: 0.15ch;
+        animation: blink 1s steps(2, end) infinite;
+    }
     @keyframes blink { 50% { opacity: 0; } }
+
+    .crest {
+        inline-size: clamp(64px, 14vw, 88px);
+        block-size: clamp(64px, 14vw, 88px);
+        border-radius: 18px;
+        object-fit: cover;
+        background: var(--color-mantle);
+        border: 1px solid var(--color-crust);
+    }
 }
 
-/* ---- Custom utilities (declared with @utility so they ship as classes) - */
-
-@utility crest {
-    inline-size: clamp(78px, 18vw, 112px);
-    block-size: auto;
-    border: 1px solid var(--color-paper-edge);
-    border-radius: var(--radius-card);
-    box-shadow:
-        0 0 0 6px var(--color-paper-warm),
-        0 0 0 7px var(--color-paper-edge),
-        0 8px 18px -10px oklch(20% 0.04 250 / 0.18);
-    rotate: -1.2deg;
-}
-
-/* ---- Accessibility / print ------------------------------------------- */
+/* ---- Accessibility / print ----------------------------------------- */
 
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
@@ -344,7 +337,5 @@
 @media print {
     body::before { display: none; }
     body { background: white; }
-    .paper-card.paper-card--warm,
-    .site-foot { display: none; }
-    .paper-card { box-shadow: none; border-color: black; }
+    .card { box-shadow: none; border-color: black; }
 }


### PR DESCRIPTION
## Summary

Two threads bundled because the SEO work depends on the redesign's tokens and components.

### 1. Redesign on Catppuccin Latte

- Drops the postal-inspector chrome (paper noise grain, rotated postmark circles, "Bureau of Mail Exchange" framing, italic Fraunces with SOFT-axis tricks) in favour of a calmer modern aesthetic.
- Full **Catppuccin Latte** palette as `@theme` tokens: surfaces (base, mantle, crust, surface-0..2), overlays (0..2), text (subtext-0..1, text), and all 14 accents. Category accents map to palette colours: mailbox=green, consumer=blue, gateway=red, forwarder=mauve, relay=peach, parking=overlay-1.
- New type stack: **Bricolage Grotesque Variable** (display, wdth+wght+opsz axes), **Onest Variable** (body), **JetBrains Mono Variable** (mono). All self-hosted via `@fontsource-variable`.
- Background is a soft two-blob radial mesh (`color-mix` of lavender + teal) — no SVG noise overlay, zero asset bytes.
- Explicit grid tracks everywhere fixes alignment issues:
    - `.finding` is `1fr auto`, `align-items: baseline`, with the badge `align-self: center` so the provider name + category pill sit on the same line cleanly.
    - Input + button share `block-size: 3.25rem` so they line up exactly.
    - `.report-row` divides the result card into consistent 1.25rem-padded rows.
- Bundle: **636 kB → 510 kB** (Fraunces + Figtree dropped).

### 2. Per-provider SEO pages

Static landing page generated for every entry in `PROVIDERS` at `/provider/<slug>/` (161 pages):

- Unique `<title>`, meta description, canonical URL per page.
- Open Graph + Twitter card with `og:site_name`, per-page `title`/`description`/`image`/`url`.
- Robots meta: `index, follow, max-image-preview:large, max-snippet:-1`.
- JSON-LD `@graph` with `Organization` (publisher), `BreadcrumbList`, and `WebPage` whose `about` is the provider Organization with `sameAs` to its official site.
- Microdata on the profile card (`itemscope`/`itemtype` Organization, `itemprop` name/description/sameAs).
- Visible breadcrumb nav (Home / {Provider}).
- Provider-specific H1 + category badge, MX hostname patterns, category explainer block, cross-links to up to 8 other providers in the same category.
- `sitemap.xml` + `robots.txt` generated at build time from `PROVIDERS`.

Homepage copy de-jargoned: no more "MX records", "security gateway", or "forwarder" in the lede; button is "Check" not "Inspect".

### Layout / dev

`index.html` is now a template with `{{TITLE}}`, `{{CANONICAL}}`, `{{HERO_*}}`, `{{PROFILE_SECTION}}`, `{{JSON_LD}}`, etc. — `scripts/build.ts` reads it once and substitutes per-page values. Slug collision detection fails the build if two providers ever produce the same slug.

## Test plan

- [ ] Build is green (lint + typecheck + Tailwind + Bun bundle).
- [ ] `dist/sitemap.xml` lists 162 URLs (homepage + 161 providers).
- [ ] `dist/robots.txt` allows all + points at the sitemap.
- [ ] `dist/index.html` and `dist/provider/google-workspace/index.html` both validate (manually skim the HTML).
- [ ] Pull the branch locally: `bun install && bun run dev`, hit `/`, `/provider/google-workspace/`, `/provider/proofpoint/` — confirm copy is non-technical on `/`, breadcrumbs render on provider pages, layout is well-aligned on mobile + desktop.
- [ ] Run a couple of real lookups (`microsoft.com`, `gmail.com`, a Proofpoint-fronted domain) and confirm the new badge/card design looks right.
- [ ] After merge, verify Google Search Console picks up the new URLs from `sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)