### PR TITLE
Link result providers to internal SEO pages, drop footer sitemap link

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,8 +83,6 @@
             <span>GitHub</span>
         </a>
         <span class="text-surface-1">·</span>
-        <a href="/sitemap.xml" class="hover:text-text transition-colors">Sitemap</a>
-        <span class="text-surface-1">·</span>
         <span>&copy; {{YEAR}} <a href="https://studio.viktopia.io" target="_blank" rel="noopener">Viktopia Studio</a></span>
     </footer>
 </body>

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,5 +1,5 @@
 import type { ConsumerHit, Finding, MxRecord } from './types.ts';
-import { CATEGORY_LABEL, CATEGORY_NOTE } from './providers.ts';
+import { CATEGORY_LABEL, CATEGORY_NOTE, providerSlug } from './providers.ts';
 
 function el<K extends keyof HTMLElementTagNameMap>(
     tag: K,
@@ -70,9 +70,10 @@ function findingBlock(finding: Finding): HTMLElement {
     const cat = provider.category;
     const block = el('div', { class: 'finding' });
 
-    const title = provider.url
-        ? el('a', { class: 'display-name finding-title', href: provider.url, target: '_blank', rel: 'noopener' }, provider.name)
-        : el('h3', { class: 'display-name finding-title' }, provider.name);
+    const title = el('a', {
+        class: 'display-name finding-title',
+        href: `/provider/${providerSlug(provider)}/`,
+    }, provider.name);
     block.append(title);
     block.append(el('div', { class: 'finding-badge' }, categoryBadge(cat)));
 


### PR DESCRIPTION
## Summary

Two small tweaks requested after the SEO PR landed:

- **Result-card provider name → internal page.** Previously, the identified provider in a lookup result linked out to its official site (e.g. `https://workspace.google.com`), sending users off the site after one click. Now it links to `/provider/<slug>/` — the dedicated profile page we generate for SEO, which already surfaces the official-site link inside.
- **Drop the footer sitemap link.** `sitemap.xml` is still served at `/sitemap.xml` and referenced from `robots.txt`; users don't need a visible UI affordance for it.

## Test plan

- [ ] Build green (lint + typecheck + Tailwind + bundle).
- [ ] Run a lookup (e.g. `microsoft.com`) — clicking the provider name in the result goes to `/provider/microsoft-365/` in the same tab, not to `microsoft.com/microsoft-365` in a new tab.
- [ ] Footer no longer shows the "Sitemap" link.
- [ ] `/sitemap.xml` still serves and is referenced from `/robots.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)